### PR TITLE
chore: setup npm publishing with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "access": "public",
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "browserbase/convex-stagehand"
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: |
+          rm -rf node_modules
+          npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "convex-stagehand",
+  "name": "@browserbasehq/convex-stagehand",
   "version": "0.0.1",
   "description": "Convex component for AI-powered browser automation with Stagehand",
   "type": "module",
@@ -38,7 +38,10 @@
     "typecheck": "tsc --noEmit && cd example && tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run --typecheck",
-    "test:watch": "vitest --typecheck"
+    "test:watch": "vitest --typecheck",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "release": "npm run build && changeset publish"
   },
   "keywords": [
     "convex",
@@ -55,6 +58,9 @@
     "type": "git",
     "url": "https://github.com/browserbase/convex-stagehand"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "zod-to-json-schema": "^3.23.0"
   },
@@ -63,6 +69,8 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
+    "@changesets/cli": "^2.27.9",
     "@eslint/js": "^9.0.0",
     "@types/node": "^20.10.0",
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
## Summary
Sets up automated npm publishing infrastructure for `@browserbasehq/convex-stagehand` using changesets, following the same pattern as the main stagehand repository.

## Changes
- **Package naming**: Renamed from `convex-stagehand` to `@browserbasehq/convex-stagehand`
- **Changesets integration**: Added `@changesets/cli` and `@changesets/changelog-github` for versioning and changelog generation
- **Release scripts**: Added `changeset`, `version`, and `release` scripts to package.json
- **GitHub Actions workflow**: Added `.github/workflows/release.yml` for automated releases on main branch pushes
- **Publish config**: Added `publishConfig` with `"access": "public"` for npm publishing
- **Changeset config**: Added `.changeset/config.json` with GitHub changelog integration

## Publishing Workflow
1. Contributors create changesets with `npm run changeset` describing their changes
2. When merged to main, the workflow creates a "Version Packages" PR
3. Merging the Version Packages PR triggers automatic npm publish

## Test plan
- [ ] Verify package.json updates are correct
- [ ] Test creating a changeset locally with `npm run changeset`
- [ ] Confirm GitHub Actions workflow syntax is valid
- [ ] After merge, monitor the release workflow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)